### PR TITLE
Fix Condition Re-rolling

### DIFF
--- a/src/module/roller/roller.mjs
+++ b/src/module/roller/roller.mjs
@@ -130,7 +130,8 @@ export function _getRollSummaryData(rollHtml) {
     fhRollQuery.find('input').each((_index, element) => {
       containsRollData = true;
 
-      if (!element.disabled) {
+      // The roll counts if it is enabled or if it is a hexed reroll die (which counts but is also disabled from being re-rolled).
+      if (!element.disabled || element.classList.contains('fh-hexed-reroll')) {
         const rollData = _parseRoll(element);
         rolls.push(rollData);
       }

--- a/src/styles/global/_roller.less
+++ b/src/styles/global/_roller.less
@@ -28,4 +28,9 @@
     filter: brightness(0.6) opacity(25%);
     border: 5px solid #42004e;
   }
+  
+  input[type=checkbox]:disabled.fh-hexed-reroll {
+    filter: opacity(75%);
+    border: 5px solid #6466ff;
+  }
 }

--- a/src/templates/chat/chat-roll.hbs
+++ b/src/templates/chat/chat-roll.hbs
@@ -1,4 +1,4 @@
-<div class='fh-evaluated-roll'>{{{evaluatedRollHtml}}}</div>
+<div class='fh-evaluated-roll fh-hexable-roll'>{{{evaluatedRollHtml}}}</div>
 <div class='fh-active-effects'>{{{activeEffectsHtml}}}</div>
 
 {{#if poisonRollHtml}}


### PR DESCRIPTION
- Fixed armor rolls not being hexed
- Properly support hexes for re-rolls
- Prevented blind and poison from being triggered on an armor roll.